### PR TITLE
Performance and bug fixes

### DIFF
--- a/config.py.template
+++ b/config.py.template
@@ -5,5 +5,9 @@ LOGIN, PASSWORD = 'someone@gmail.com', 'password'
 # with spaces, such as:
 # IMAP_FOLDER = '"[Gmail]/All Mail"'
 IMAP_FOLDER = '[Gmail]/Inbox'
+# just run the indexing pass, not the download / label update pass?
 INDEX_ONLY = False
+# generate debugging output?
 DEBUG = False
+# print message statistics and info about degenerate or problematic messages?
+MESSAGE_DETAILS = False


### PR DESCRIPTION
I've done a bunch of work atop your initial baseline.

The biggest change is to fix some O(N^2) behavior in the message lookup that was making it unusably slow.  I also started adding code to index the GMail message IDs to allow handling messages with no Message-ID, or with duplicated ones.  The indexing is there, and the gmail id is passed to apply_labels, but I haven't implemented actually using the gmail id yet.

Also handled are some degenerate / uncommon cases: messages with multiple message-id fields, messages with comments in the message-id header.

Some other minor fixes:

I tested and this indeed does not work with any python version before 3.3, so I updated the shebang line to reflect that.

The message header into which it was saving the GMail labels was not the same name as what the GMail IMAP server returns initially, fixed that.  Ditto for the GMail message id.

I made some minor improvements to the script output, including disabling progress reporting when run without a tty, e.g. from cron.
