### PR TITLE
Improved handling of non-ideal messages, handle message header encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config*.py
 __pycache__
+gmail-restore-labels.labels.pickle
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config*.py
 __pycache__
 gmail-restore-labels.labels.pickle
 *~
+mailbackup

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-config.py
+config*.py
 __pycache__
 *~

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 How this is supposed to work
 ============================
 
-This script should download message labels from gmail and apply them on local copy of that messages (made with [getmail](http://pyropus.ca/software/getmail/) or other software) either as tags in notmuch database ([notmuch, the mail indexer](http://notmuchmail.org/), something like offline gmail in shell) or as header in messages.
+This script should download message labels from gmail and apply them on
+local copy of that messages (made with
+[getmail](http://pyropus.ca/software/getmail/) or other software) as header
+in messages.
 
 Idea is really simple:
 
-1. if not using notmuch: 
-    1. prepare index "Message-ID header" => "message file"
-    2. save index in $MAILDIR/gmail-sync-labels.index
-2. Download (message-id, labels) pairs from gmail
-3. Apply labels on message with message-id
+1. prepare index "Message-ID header" => "message file"
+2. save index in $MAILDIR/gmail-sync-labels.index
+3. Download (message-id, labels) pairs from gmail
+4. Apply labels on message with message-id
 
 How to use this
 =============
 
-before: make backup of your Maildir. It works for me, but it may destroy mails for you. It was tested with python 3.3, it may or may not work with older releases. Feel free to post patches / pull requests / issues about older versions.
+before: make backup of your Maildir.  It works for me, but it may destroy
+mails for you.  It was tested with python 3.3, it may or may not work with
+older releases.  Feel free to post patches / pull requests / issues about
+older versions.
 
     cp config.py.template config.py
-    edit config.py
-    python3 gmail-sync-labels.py
+    edit config_named.py
+    python3 gmail-sync-labels.py config_named

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ keying by message ID.  Note that this tool is not well tested.
     edit config_old.py config_new.py
     python3 gmail-restore-labels.py config_old config_new
 
-similar projects
+Similar Projects
 ================
 
 1. [gmail-notmuch](http://git.zx2c4.com/gmail-notmuch/)
+   <br/>This project used to have NotMuch support, but it was removed for lack of maintenance.
+
+See Also
+=============
+* https://github.com/hiciu/gmail-sync-labels
+* https://github.com/fastcat/gmail-sync-labels

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ mails for you.  It was tested with python 3.3, it may or may not work with
 older releases.  Feel free to post patches / pull requests / issues about
 older versions.
 
-    cp config.py.template config.py
+    cp config.py.template config_named.py
     edit config_named.py
     python3 gmail-sync-labels.py config_named
+
+How to use the label restorer
+=============================
+
+The restorer currently works by copying from one gmail account to another,
+keying by message ID.  Note that this tool is not well tested.
+
+    cp config.py.template config_old.py
+    cp config.py.template config_new.py
+    edit config_old.py config_new.py
+    python3 gmail-restore-labels.py config_old config_new

--- a/config.py.template
+++ b/config.py.template
@@ -1,5 +1,4 @@
 MAILDIR = '/home/someone/Maildir'
-USE_NOTMUCH = False
 LOGIN, PASSWORD = 'someone@gmail.com', 'password'
 # some versions of imaplib need extra quotes in here if you use a mailbox
 # with spaces, such as:

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -136,7 +136,7 @@ def apply_labels(gmail, cfg, index):
             added += 1
             #print("%s" % (data,))
         # apply is slow, print all the time
-        if True || count % 100 == 0:
+        if True or count % 100 == 0:
             print("Apply: %7d (%8d) / %7d" % (count, added, total), end='\r')
     print("Apply: %7d (%8d) / %7d -- Done" % (count, added, total))
 

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -111,7 +111,7 @@ def create_label_index(gmail, cfg):
         msglabels.update(map_labels(labels))
         count += 1
         if count % 100 == 0:
-            print("Fetch: %7d / %7d" % (count, total), end='\r')
+            print("Fetch: %7d / %7d" % (count, total), end='\r', flush=True)
     print("Fetch: %7d / %7d -- Done" % (count, total))
     return index
 
@@ -137,7 +137,7 @@ def apply_labels(gmail, cfg, index):
             #print("%s" % (data,))
         # apply is slow, print all the time
         if True or count % 100 == 0:
-            print("Apply: %7d (%8d) / %7d" % (count, added, total), end='\r')
+            print("Apply: %7d (%8d) / %7d" % (count, added, total), end='\r', flush=True)
     print("Apply: %7d (%8d) / %7d -- Done" % (count, added, total))
 
 def main():

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -111,13 +111,14 @@ def create_label_index(gmail, cfg):
         msglabels.update(map_labels(labels))
         count += 1
         if count % 100 == 0:
-            print("Fetch: %7d/%7d" % (count, total), end='\r')
-    print("Fetch: %7d/%7d -- Done" % (count, total))
+            print("Fetch: %7d / %7d" % (count, total), end='\r')
+    print("Fetch: %7d / %7d -- Done" % (count, total))
     return index
 
 def apply_labels(gmail, cfg, index):
     total = gmail.selectfolder(cfg.IMAP_FOLDER)
     count = 0
+    added = 0
     for uid, msgid, labels in download_labels(gmail, total):
         count += 1
         msgwantlabels = index.get(msgid)
@@ -132,10 +133,12 @@ def apply_labels(gmail, cfg, index):
         for l in msgneedlabels:
             type, data = gmail.uid('COPY', uid, l)
             assert type == 'OK'
+            added += 1
             #print("%s" % (data,))
-        if count % 100 == 0:
-            print("Apply: %7d/%7d" % (count, total), end='\r')
-    print("Apply: %7d/%7d -- Done" % (count, total))
+        # apply is slow, print all the time
+        if True || count % 100 == 0:
+            print("Apply: %7d (%8d) / %7d" % (count, added, total), end='\r')
+    print("Apply: %7d (%8d) / %7d -- Done" % (count, added, total))
 
 def main():
     labelsfile = 'gmail-restore-labels.labels.pickle'

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -145,9 +145,13 @@ def apply_labels(gmail, cfg, index):
         # apply is slow, print all the time
         if True or count % 100 == 0:
             remaining = total - count
+            if remaining <= 0:
+            	# wtf?
+            	remaining = 0
             now = time.time()
             if modified != 0:
                 eta = start + (now - start) * remaining / modified
+                assert eta >= start, "%f %f %d %d %d %d" % (start, now, total, count, remaining, modified)
                 etastring = datetime.datetime.fromtimestamp(eta).strftime('%Y-%m-%d %H:%M:%S')
             else:
                 etastring = '?'

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -121,7 +121,7 @@ def apply_labels(gmail, cfg, index):
     added = 0
     for uid, msgid, labels in download_labels(gmail, total):
         count += 1
-        msgwantlabels = index.get(msgid)
+        msgwantlabels = index.get(msgid, set())
         if len(msgwantlabels) == 0:
             print("No labels for %s" % msgid)
         msghaslabels = set(map_labels(labels))

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -112,7 +112,7 @@ def create_label_index(gmail, cfg):
         count += 1
         if count % 100 == 0:
             print("Fetch: %7d/%7d" % (count, total), end='\r')
-    print('\nDone')
+    print("Fetch: %7d/%7d -- Done" % (count, total))
     return index
 
 def apply_labels(gmail, cfg, index):
@@ -135,7 +135,7 @@ def apply_labels(gmail, cfg, index):
             #print("%s" % (data,))
         if count % 100 == 0:
             print("Apply: %7d/%7d" % (count, total), end='\r')
-    print('\nDone')
+    print("Apply: %7d/%7d -- Done" % (count, total))
 
 def main():
     labelsfile = 'gmail-restore-labels.labels.pickle'

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -28,6 +28,9 @@ class Gmail(imaplib.IMAP4_SSL):
         self.login(cfg.LOGIN, cfg.PASSWORD)
 
         assert 'X-GM-EXT-1' in self.capabilities
+        
+        # set a timeout for further ops so that it doesn't hang on network hiccups
+        self.socket().settimeout(30.0)
 
     def selectfolder(self, folder, readonly=True):
         resp = self.select(folder, readonly)

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -122,13 +122,10 @@ def apply_labels(gmail, cfg, index):
     for uid, msgid, labels in download_labels(gmail, total):
         count += 1
         msgwantlabels = index.get(msgid)
-        if msgwantlabels is None:
+        if len(msgwantlabels) == 0:
             print("No labels for %s" % msgid)
-            continue
         msghaslabels = set(map_labels(labels))
         msgneedlabels = msgwantlabels - msghaslabels
-        if len(msgneedlabels) == 0:
-            continue
         #print("Message %s has %s, should have %s, add %s" % (msgid, msghaslabels, msgwantlabels, msgneedlabels))
         for l in msgneedlabels:
             type, data = gmail.uid('COPY', uid, l)

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -109,7 +109,7 @@ def create_label_index(gmail, cfg):
     for uid, msgid, labels in download_labels(gmail, total):
         msglabels = index.setdefault(msgid, set())
         msglabels.update(map_labels(labels))
-        ++count
+        count += 1
         if count % 100 == 0:
             print("Fetch: %7d/%7d" % (count, total), end='\r')
     return index
@@ -118,7 +118,7 @@ def apply_labels(gmail, cfg, index):
     total = gmail.selectfolder(cfg.IMAP_FOLDER)
     count = 0
     for uid, msgid, labels in download_labels(gmail, total):
-        ++count
+        count += 1
         msgwantlabels = index.get(msgid)
         if msgwantlabels is None:
             print("No labels for %s" % msgid)

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python3
+
+import config_oldbw
+import config_newbw
+import email.header
+import imaplib
+import os
+import pprint
+import re
+import shelve
+import ssl
+
+class Gmail(imaplib.IMAP4_SSL):
+    def __init__(self, cfg):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        ctx.set_default_verify_paths()
+        # XXX: alternative, should work too:
+        # ctx.load_verify_locations('/etc/ssl/certs/ca-certificates.crt')
+
+        imaplib.IMAP4_SSL.__init__(self, 'imap.gmail.com', 993, ssl_context=ctx)
+
+        # XXX: I have no idea how to check / if I need to check that thing. State from 2012-12-14.
+        # MGL: set_default_verify_paths should do the work, as long as openssl is configured properly
+        # assert self.sock.getpeercert() == {'subject': ((('countryName', 'US'),), (('stateOrProvinceName', 'California'),), (('localityName', 'Mountain View'),), (('organizationName', 'Google Inc'),), (('commonName', 'imap.gmail.com'),)), 'serialNumber': '3B73268B0000000068A5', 'subjectAltName': (('DNS', 'imap.gmail.com'),), 'version': 3, 'notBefore': 'Sep 12 11:55:49 2012 GMT', 'notAfter': 'Jun  7 19:43:27 2013 GMT', 'issuer': ((('countryName', 'US'),), (('organizationName', 'Google Inc'),), (('commonName', 'Google Internet Authority'),))}
+
+        self.login(cfg.LOGIN, cfg.PASSWORD)
+
+        assert 'X-GM-EXT-1' in self.capabilities
+
+    def selectfolder(self, folder, readonly=True):
+        resp = self.select(folder, readonly)
+        assert resp[0] == 'OK'
+
+        total = int(resp[1][0])
+        assert total > 0
+
+        return total
+
+def download_labels(gmail, total):
+    resp = gmail.fetch('1:%d' % total, '(X-GM-THRID X-GM-MSGID X-GM-LABELS BODY[HEADER.FIELDS (MESSAGE-ID)])')
+
+    assert resp[0] == 'OK'
+
+    """
+    response here is ugly:
+
+    [(b'1 (X-GM-MSGID 1222139561679786370 X-GM-LABELS () BODY[HEADER.FIELDS (MESSAGE-ID)] {61}',
+      b'Message-ID: <a38097d40612071225s1e399c3eu@mail.gmail.com>\r\n\r\n'),
+     b')',
+     (b'2 (X-GM-MSGID 1222140200241725271 X-GM-LABELS () BODY[HEADER.FIELDS (MESSAGE-ID)] {40}',
+      b'Message-ID: <45787AFA.7020202@wp.pl>\r\n\r\n'),
+     b')',
+     ...
+    ]
+    """
+    regexp = re.compile('(\d+) \(X-GM-THRID (\d+) X-GM-MSGID (\d+) X-GM-LABELS \((.*)\) BODY\[HEADER.FIELDS \(MESSAGE-ID\)\] {(\d+)}')
+
+    # every even (2, 4, 6, 8, ...) item from response should be b')'
+    for even_item in resp[1][1::2]:
+        assert even_item == b')'
+
+    # every odd (1, 3, 5, 7, ...) item should match regexp
+    for odd_item in resp[1][::2]:
+        imapid, gmailthreadid, gmailid, labels, payloadlen = regexp.match(odd_item[0].decode('utf-8')).groups()
+
+        assert int(payloadlen) == len(odd_item[1])
+
+        try:
+            msgid = odd_item[1].decode('utf-8').split()[1]
+        except IndexError:
+            if config.DEBUG or config.MESSAGE_DETAILS:
+                print('got message without Message-ID header: '
+                      'gmail id %s, link: https://mail.google.com/mail/#all/%s'
+                      % (gmailid, hex(int(gmailthreadid))[2:])
+                )
+            #continue
+            # allow update by gmail id
+            msgid = None
+
+        yield msgid, gmailid, gmailthreadid, labels
+
+def create_label_index(gmail, cfg):
+    total = gmail.selectfolder(cfg.IMAP_FOLDER)
+    index = dict()
+    for msgid, gmailid, gmailthreadid, labels in download_labels(gmail, total):
+        raise Exception('Not Implemented')
+
+def apply_labels(gmail, cfg, index):
+    raise Exception('Not Implemented')
+
+def main():
+    labelsfile = 'gmail-restore-labels.labels.pickle'
+    index = None
+    try:
+        with open(labelsfile, 'rb') as f:
+            index = pickle.load(f)
+    except FileNotFoundError:
+        print('No index file, will generate one')
+        index = None
+    if index is None:
+        with oldgmail = Gmail(config_oldbw):
+            index = create_label_index(oldgmail, cfg_oldbw)
+        with open(labelsfile, 'rb') as f:
+            pickle.dump(index, f)
+    
+    with newgmail = Gmail(config_newbw):
+        apply_labels(newgmail, config_newbw, index)
+    
+    return
+
+if __name__ == "__main__":
+    main()

--- a/gmail-restore-labels.py
+++ b/gmail-restore-labels.py
@@ -112,6 +112,7 @@ def create_label_index(gmail, cfg):
         count += 1
         if count % 100 == 0:
             print("Fetch: %7d/%7d" % (count, total), end='\r')
+    print('\nDone')
     return index
 
 def apply_labels(gmail, cfg, index):
@@ -134,7 +135,7 @@ def apply_labels(gmail, cfg, index):
             #print("%s" % (data,))
         if count % 100 == 0:
             print("Apply: %7d/%7d" % (count, total), end='\r')
-    raise Exception('Not Implemented')
+    print('\nDone')
 
 def main():
     labelsfile = 'gmail-restore-labels.labels.pickle'

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -130,7 +130,8 @@ class MaildirDatabase(mailbox.Maildir):
             info = self.__message_ids[key]
             gmailid = info['X-GMAIL-MSGID']
             if gmailid != None:
-                assert gmailid not in self.__gmail_id_to_key.keys(), 'duplicate gmail id %s' % gmailid
+                assert gmailid not in self.__gmail_id_to_key.keys(), 'duplicate gmail id %s in %s and %s' % (
+                    gmailid, key, self.__gmail_id_to_key[gmailid])
                 self.__gmail_id_to_key[gmailid] = key
             messageids = info['Message-ID']
             for messageid in messageids:

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -26,7 +26,7 @@ import ssl
 if config.USE_NOTMUCH:
     import notmuch
 
-DATA_VERSION = 2
+DATA_VERSION = 3
 
 class Gmail(imaplib.IMAP4_SSL):
     def __init__(self, login, password):

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -353,6 +353,9 @@ def main():
 
     total = len(db)
 
+    updated_msgs = 0
+    errors = 0
+    
     try:
         print('searching for new messages')
 
@@ -372,8 +375,6 @@ def main():
         i = 0
 
         print('downloading and applying labels')
-        updated_msgs = 0
-        errors = 0
         for msgid, gmailid, gmailthreadid, labels in download_labels(gmail, total):
             i += 1
             if i % 10 == 0 and os.isatty(1):
@@ -384,9 +385,13 @@ def main():
                 errors += 1
             else:
                 updated_msgs += updaterc
-        print('Updated %d messages, %d errors' % (updated_msgs, errors))
-
+    except imaplib.IMAP4.error as err:
+        if os.isatty(1):
+            print('') # flush progress line
+        print('Failed with imap error:', file=sys.stderr)
+        print(err, file=sys.stderr)
     finally:
+        print('Updated %d messages, %d errors' % (updated_msgs, errors))
         # extra whitespace at end to ensure it fully overwrites progress line
         print('saving database ')
         db.close()

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -383,7 +383,7 @@ def main():
 
         for progress in db.init():
             if os.isatty(1):
-                print('progress: %0.2f%%' % float(progress * 100 / total), end='\r')
+                print('progress: %0.2f%%' % float(progress * 100 / total), end='\r', flush=True)
         
         if config.INDEX_ONLY:
             print('indexing complete')
@@ -402,7 +402,7 @@ def main():
         for msgid, gmailid, gmailthreadid, labels in download_labels(gmail, total):
             i += 1
             if i % 10 == 0 and os.isatty(1):
-                print('progress: %0.2f%%' % float(i * 100 / total), end='\r')
+                print('progress: %0.2f%%' % float(i * 100 / total), end='\r', flush=True)
 
             updaterc = db.apply_labels(msgid, gmailid, gmailthreadid, labels)
             if updaterc < 0:

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -43,6 +43,7 @@ def header_to_string(headervalue):
             raise
     return str(header)
 
+#FIXME: refactor to separate file to share code
 class Gmail(imaplib.IMAP4_SSL):
     def __init__(self, login, password):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
@@ -291,6 +292,7 @@ class MaildirDatabase(mailbox.Maildir):
         
         return 1
 
+#FIXME: refactor to separate class o share code
 def download_labels(gmail, total):
     """
     response here is ugly:
@@ -369,6 +371,8 @@ def main():
 
         print('connecting to gmail')
         gmail = Gmail(config.LOGIN, config.PASSWORD)
+
+        gmail.debug = 15;
 
         print('selecting mailbox')
         total = gmail.selectfolder(config.IMAP_FOLDER)

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -124,15 +124,18 @@ class MaildirDatabase(mailbox.Maildir):
         self.__message_keys_without_id = set()
         # same problem with message ids that are duplicated
         self.__duplicated_message_ids = set()
+        foundfatalerrors = False
         for key in self.__message_ids:
             if key == '__VERSION':
                 continue
             info = self.__message_ids[key]
             gmailid = info['X-GMAIL-MSGID']
             if gmailid != None:
-                assert gmailid not in self.__gmail_id_to_key.keys(), 'duplicate gmail id %s in %s and %s' % (
-                    gmailid, key, self.__gmail_id_to_key[gmailid])
-                self.__gmail_id_to_key[gmailid] = key
+                if gmailid in self.__gmail_id_to_key.keys():
+                    print('duplicate gmail id %s in %s and %s' % (gmailid, key, self.__gmail_id_to_key[gmailid]))
+                    foundfatalerrors = True
+                else:
+                    self.__gmail_id_to_key[gmailid] = key
             messageids = info['Message-ID']
             for messageid in messageids:
                 if messageid in self.__message_id_to_key.keys():
@@ -149,6 +152,8 @@ class MaildirDatabase(mailbox.Maildir):
             print('cached index: %d good message ids, %d duplicated ids, %d missing ids' %
                 (len(self.__message_id_to_key), len(self.__duplicated_message_ids),
                 len(self.__message_keys_without_id)))
+        if foundfatalerrors:
+            assert False, 'Found fatal errors, cannot continue'
 
     def init(self):
         i = 0

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3.3
+#!/usr/bin/python3
 
 """
 Copyright (C) 2013 Krzysztof Warzecha <kwarzecha7@gmail.com>

--- a/gmail-sync-labels.py
+++ b/gmail-sync-labels.py
@@ -392,22 +392,20 @@ def main():
         total = gmail.selectfolder(config.IMAP_FOLDER)
         i = 0
 
-        print('downloading and applying labels')
+        print('downloading and applying labels for %d messages' % total)
         for msgid, gmailid, gmailthreadid, labels in download_labels(gmail, total):
+            checked_msgs += 1
             i += 1
             if i % 10 == 0 and os.isatty(1):
-                print('progress: %0.2f%%' % float(i * 100 / total), end='\r', flush=True)
+                print('progress: %0.2f%% %d' % (float(i * 100 / total), checked_msgs), end='\r', flush=True)
 
             updaterc = db.apply_labels(msgid, gmailid, gmailthreadid, labels)
-            checked_msgs += 1
             if updaterc < 0:
                 errors += 1
             else:
                 updated_msgs += updaterc
     except imaplib.IMAP4.error as err:
-        if os.isatty(1):
-            print('') # flush progress line
-        print('Failed with imap error:', file=sys.stderr)
+        print('\nFailed with imap error:', file=sys.stderr)
         print(err, file=sys.stderr)
     finally:
         print('Updated %d/%d messages, %d errors' % (updated_msgs, checked_msgs, errors))


### PR DESCRIPTION
Here is more work I've added.  The older commits are mainly about managing degenerate cases and gracefully handling semi-invalid data.

The latest commit is to deal with a change in the GMail IMAP interface, where many GMail-added message headers are now put in UTF-8 encoding (e.g. "=?utf-8?q?blahblahblah?=") even if their values are entirely ASCII.  This was breaking some of the message indexing.
